### PR TITLE
feature: remove class functions from exported formControl type

### DIFF
--- a/projects/ngx-form-app/src/app/form/user.form.ts
+++ b/projects/ngx-form-app/src/app/form/user.form.ts
@@ -36,4 +36,8 @@ export class UserForm {
   public constructor(data: Partial<UserForm> = {}) {
     Object.assign(this, data);
   }
+
+  public getFullName(): string {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }

--- a/projects/ngx-form/src/lib/common/common.spec.ts
+++ b/projects/ngx-form/src/lib/common/common.spec.ts
@@ -6,6 +6,8 @@ import { transformSmartValueToValue, transformValueToSmartValue } from './common
 import { FormArray } from '../decorator/form-array.decorator';
 import { TestBed } from '@angular/core/testing';
 import { provideNgxForm } from '../ngx-form.module';
+import {NgxFormControl} from '../model/ngx-form-control.model';
+import {NgxFormArray} from '../model/ngx-form-array.model';
 
 class UserForm {
 
@@ -17,6 +19,10 @@ class UserForm {
 
   @FormArray({defaultValue: 'Default skill'})
   public skills: string[];
+
+  public getFullName(): string {
+    return `${this.firstName} ${this.lastName}`;
+  }
 }
 
 let builder: NgxFormBuilder;
@@ -46,4 +52,25 @@ describe('Common', () => {
   it('should transform smart value to value', () => {
     expect(transformSmartValueToValue(new UserForm())).toBeInstanceOf(Object);
   })
+
+  it('should not expose functions as controls', () => {
+    expect(form.controls['getFullName']).toBeUndefined();
+  })
+
+  it('should expose all controls', () => {
+    expect(form.controls.firstName).toBeDefined();
+    expect(form.controls.lastName).toBeDefined();
+    expect(form.controls.skills).toBeDefined();
+  })
+
+  it('should expose all controls as FormControl', () => {
+    expect(form.controls.firstName).toBeInstanceOf(NgxFormControl);
+    expect(form.controls.lastName).toBeInstanceOf(NgxFormControl);
+    expect(form.controls.skills).toBeInstanceOf(NgxFormArray);
+  });
+
+  it('should expose functions when retrieving value', () => {
+    expect(form.getValue().getFullName).toBeDefined();
+  });
+
 })

--- a/projects/ngx-form/src/lib/common/common.spec.ts
+++ b/projects/ngx-form/src/lib/common/common.spec.ts
@@ -6,8 +6,8 @@ import { transformSmartValueToValue, transformValueToSmartValue } from './common
 import { FormArray } from '../decorator/form-array.decorator';
 import { TestBed } from '@angular/core/testing';
 import { provideNgxForm } from '../ngx-form.module';
-import {NgxFormControl} from '../model/ngx-form-control.model';
-import {NgxFormArray} from '../model/ngx-form-array.model';
+import { NgxFormControl } from '../model/ngx-form-control.model';
+import { NgxFormArray } from '../model/ngx-form-array.model';
 
 class UserForm {
 

--- a/projects/ngx-form/src/lib/common/common.ts
+++ b/projects/ngx-form/src/lib/common/common.ts
@@ -8,6 +8,15 @@ import { Observable } from 'rxjs';
 import { NgxFormControl } from '../model/ngx-form-control.model';
 import { set } from './functions/set';
 
+
+type MarkFunctionProperties<Component> = {
+  [Key in keyof Component]: Component[Key] extends Function ? never : Key;
+};
+
+type ExcludedFunctionPropertyNames<T> = MarkFunctionProperties<T>[keyof T];
+
+type ExcludeFunctions<T> = Pick<T, ExcludedFunctionPropertyNames<T>>;
+
 export interface Handler {
 
   handle<T>(type: () => ConstructorFunction<T>, instance: NgxFormGroup<T>, unsubscribeOn: Observable<any>): void;
@@ -102,7 +111,7 @@ type IterableElement<TargetIterable> =
       ElementType :
       never;
 
-export type DataToFormType<V, K extends keyof V = keyof V> = {
+export type DataToFormType<V, K extends keyof ExcludeFunctions<V> = keyof ExcludeFunctions<V>> = {
   [key in K]: V[key] extends Primitive ? NgxFormControl<V[key]> : V[key] extends Arrayable<IterableElement<V[key]>> ? NgxFormArray<IterableElement<V[key]>> : NgxFormGroup<V[key]>
 };
 export type DataFormType<V> = Partial<V> & {[key: string]: any};

--- a/projects/ngx-form/src/lib/common/common.ts
+++ b/projects/ngx-form/src/lib/common/common.ts
@@ -9,8 +9,8 @@ import { NgxFormControl } from '../model/ngx-form-control.model';
 import { set } from './functions/set';
 
 
-type MarkFunctionProperties<Component> = {
-  [Key in keyof Component]: Component[Key] extends Function ? never : Key;
+type MarkFunctionProperties<T> = {
+  [Key in keyof T]: T[Key] extends Function ? never : Key;
 };
 
 type ExcludedFunctionPropertyNames<T> = MarkFunctionProperties<T>[keyof T];

--- a/projects/ngx-form/src/lib/core/ngx-form.builder.ts
+++ b/projects/ngx-form/src/lib/core/ngx-form.builder.ts
@@ -24,7 +24,7 @@ export class NgxFormBuilder extends FormBuilder {
   public group<V extends {}>(controlsConfig: DataToFormType<V>, options?: AbstractControlOptions | null): any {
     const fg: FormGroup = super.group(controlsConfig, options);
 
-    return new NgxFormGroup<V>(fg.controls as DataToFormType<any>, {asyncValidators: fg.asyncValidator, updateOn: fg.updateOn, validators: fg.validator});
+    return new NgxFormGroup<V>(fg.controls as DataToFormType<V>, {asyncValidators: fg.asyncValidator, updateOn: fg.updateOn, validators: fg.validator});
   }
 
   public control<V>(formState: V | FormControlState<V>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions & {


### PR DESCRIPTION
Prevents IDEs from suggesting functions defined in the class used to build a formControl.

Typical use case : a class with firstname and lastname formControls, and a getFullName() function used when reading the formGroup's value.

formGroup.controls won't suggest getFullName, but formGroup.getValue() will.