### PR TITLE
feature: add File to supported primitive types

### DIFF
--- a/projects/ngx-form/src/lib/common/common.spec.ts
+++ b/projects/ngx-form/src/lib/common/common.spec.ts
@@ -17,6 +17,9 @@ class UserForm {
   @FormControl()
   public lastName: string;
 
+  @FormControl()
+  public file: File;
+
   @FormArray({defaultValue: 'Default skill'})
   public skills: string[];
 
@@ -72,5 +75,11 @@ describe('Common', () => {
   it('should expose functions when retrieving value', () => {
     expect(form.getValue().getFullName).toBeDefined();
   });
+
+  it('should correctly type primitive types forms', () => {
+    form.controls.file.setValue(new File([], 'test.txt'));
+
+    expect(form.controls.file.value).toBeInstanceOf(File);
+  })
 
 })

--- a/projects/ngx-form/src/lib/common/common.ts
+++ b/projects/ngx-form/src/lib/common/common.ts
@@ -100,7 +100,8 @@ type Primitive =
   | boolean
   | symbol
   | bigint
-  | Date;
+  | Date
+  | File;
 
 type Arrayable<T> = T[];
 


### PR DESCRIPTION
Currently a @FormControl directive applied to a File attribute results in a NgxFormGroup<File>, which messes with the typing of the data and IDE code suggestions (for example getValue() is suggested but not actually present on the instance of the control)

This PR fixes that by adding File to the custom-defined "Primitive types" enum